### PR TITLE
feat: 优化乐观锁自旋机制，提升高并发压测成功率

### DIFF
--- a/internal/repository/inventory_repo.go
+++ b/internal/repository/inventory_repo.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"demo01/internal/model"
+	"time"
 
 	"gorm.io/gorm"
 )
@@ -18,31 +19,62 @@ func NewInventoryRepo(db *gorm.DB) *InventoryRepo {
 }
 
 // 核心操作 执行商品扣减
-// DecreaseStock 扣减库存（乐观锁）
+// DecreaseStock 扣减库存（乐观锁 + 自旋重试）
 // 1.上下文  2.商品id 3.库存
 func (r *InventoryRepo) DecreaseStock(ctx context.Context, productID int, quantity int) error {
-	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var inventory model.Inventory
-		if err := tx.Where("product_id = ?", productID).First(&inventory).Error; err != nil {
+	const (
+		maxRetries = 8                     // 最大重试次数（增加重试次数）
+		baseDelay  = 5 * time.Millisecond  // 基础重试间隔
+		maxDelay   = 50 * time.Millisecond // 最大重试间隔
+	)
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			var inventory model.Inventory
+			if err := tx.Where("product_id = ?", productID).First(&inventory).Error; err != nil {
+				return err
+			}
+
+			if inventory.Stock < quantity {
+				return gorm.ErrRecordNotFound // 库存不足
+			}
+
+			// 乐观锁更新
+			result := tx.Model(&model.Inventory{}).
+				Where("product_id = ? AND version = ?", productID, inventory.Version).
+				Updates(map[string]interface{}{
+					"stock":   inventory.Stock - quantity,
+					"version": inventory.Version + 1,
+				})
+
+			if result.RowsAffected == 0 {
+				return gorm.ErrRecordNotFound // 版本冲突
+			}
+
+			return result.Error
+		})
+
+		// 如果成功或非版本冲突错误，直接返回
+		if err == nil || err != gorm.ErrRecordNotFound {
 			return err
 		}
 
-		if inventory.Stock < quantity {
-			return gorm.ErrRecordNotFound // 库存不足
+		// 版本冲突，使用指数退避策略重试
+		if attempt < maxRetries-1 {
+			// 指数退避：延迟时间随重试次数增加
+			delay := baseDelay * time.Duration(1<<attempt)
+			if delay > maxDelay {
+				delay = maxDelay
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+				// 继续重试
+			}
 		}
+	}
 
-		// 乐观锁更新
-		result := tx.Model(&model.Inventory{}).
-			Where("product_id = ? AND version = ?", productID, inventory.Version).
-			Updates(map[string]interface{}{
-				"stock":   inventory.Stock - quantity,
-				"version": inventory.Version + 1,
-			})
-
-		if result.RowsAffected == 0 {
-			return gorm.ErrRecordNotFound // 版本冲突
-		}
-
-		return result.Error
-	})
+	return gorm.ErrRecordNotFound // 达到最大重试次数
 }


### PR DESCRIPTION
- 添加乐观锁自旋重试机制，最大重试8次
- 实现指数退避策略：基础延迟5ms，最大延迟50ms
- 重试间隔随重试次数指数增长：5ms -> 10ms -> 20ms -> 40ms -> 50ms
- 支持Context超时控制，避免无限等待
- 优化高并发场景下的版本冲突处理，提升压测成功率